### PR TITLE
fix: add operational restrictions to the "Go to Admin Panel" link and the "Read this article" button

### DIFF
--- a/macuos/templates/macuos/post_list.html
+++ b/macuos/templates/macuos/post_list.html
@@ -14,11 +14,19 @@
         {% endfor %}
         <p class="text-muted">{{ post.created_at }}</p>
         {% if user.is_authenticated %}
-        <p>
-	<a class="nav-link" href="{% url 'admin:macuos_post_change' post.pk %}">>> 管理画面へ</a>
-        </p>
+          {% if user.username == "admin" %}
+            <p>
+              <a class="nav-link" href="{% url 'admin:macuos_post_change' post.pk %}">>> 管理画面へ</a>
+            </p>
+          {% endif %}
+          <a class="btn btn-outline-primary btn-lg btn-block" href="{% url 'macuos:detail' post.pk %}">>> この記事を読む</a>
+        {% else %}
+          {% if post.category.name == "PaidContent" %}
+            <a class="btn btn-outline-primary btn-lg btn-block disabled" href="{% url 'macuos:detail' post.pk %}">>> この記事を読む</a>
+          {% else %}
+            <a class="btn btn-outline-primary btn-lg btn-block" href="{% url 'macuos:detail' post.pk %}">>> この記事を読む</a>
+          {% endif %}
         {% endif %}
-	<a class="btn btn-outline-primary btn-lg btn-block" href="{% url 'macuos:detail' post.pk %}">>> この記事を読む</a>
       </div>
     </div>
   {% endfor %}


### PR DESCRIPTION
## overview
<!-- [概要] このセクションでは、このPRの目的と概要を簡潔に説明してください。-->
- The "Go to Admin Panel" link is now displayed only when logged in with admin credentials.
- The "Read this article" button for paid content (small category = `PaidContent`) is now enabled only when logged in with any user's authorization.

## changes
<!-- [変更点] このセクションでは、具体的な変更点や修正箇所を箇条書きでリストアップしてください。-->
- obvious

## scope of Impact
<!-- [影響範囲] このセクションでは、このPRが影響を及ぼす範囲や他の機能への影響を説明してください。-->
- none

## testing
<!-- [テスト] このセクションでは、このPRに関連するテストケースやテスト方法を記載してください。-->
- visual confirmation

## related Issues
<!-- [関連Issue] このセクションでは、このPRが関連するIssueやタスクをリンクしてください。-->
- #17